### PR TITLE
Fix minor typo for soft-depend -> softdepened

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ depend: [TitleManager]
 
 If your plugin can run without TitleManager, then add the following line to your plugin.yml file instead
 ```yaml
-soft-depend: [TitleManager]
+softdepend: [TitleManager]
 ```
 
 ### Getting the API instance


### PR DESCRIPTION
Spigot doesn't recognize "soft-depend". Instead, it uses "softdepend".