### PR TITLE
Added Minecraft 1.18 ScoreBoard support

### DIFF
--- a/src/main/kotlin/io/puharesource/mc/titlemanager/internal/model/scoreboard/ScoreboardHandler.kt
+++ b/src/main/kotlin/io/puharesource/mc/titlemanager/internal/model/scoreboard/ScoreboardHandler.kt
@@ -2,6 +2,7 @@ package io.puharesource.mc.titlemanager.internal.model.scoreboard
 
 import io.puharesource.mc.titlemanager.internal.pluginConfig
 import io.puharesource.mc.titlemanager.internal.reflections.ChatSerializer
+import io.puharesource.mc.titlemanager.internal.reflections.NMSManager
 import org.bukkit.ChatColor
 import org.bukkit.scoreboard.DisplaySlot
 import org.bukkit.scoreboard.Objective
@@ -100,8 +101,9 @@ class ScoreboardHandler(val scoreboard: Scoreboard, title: String = "TitleManage
     private fun setTitleWithoutLimit(title: String) {
         val craftObjectiveField = objective::class.java.getDeclaredField("objective")
         craftObjectiveField.isAccessible = true
-
         val craftObjective = craftObjectiveField.get(objective)
-        craftObjective::class.java.declaredMethods.first { it.name == "setDisplayName" }.invoke(craftObjective, ChatSerializer.deserializeLegacyText(title))
+        craftObjective::class.java.declaredMethods.first {
+            it.name == "setDisplayName" || (it.name == "a" && it.parameterTypes.contentEquals((arrayOf(NMSManager.getClassProvider()["IChatBaseComponent"].handle))))
+        }.invoke(craftObjective, ChatSerializer.deserializeLegacyText(title))
     }
 }

--- a/src/main/kotlin/io/puharesource/mc/titlemanager/internal/reflections/NMSManager.kt
+++ b/src/main/kotlin/io/puharesource/mc/titlemanager/internal/reflections/NMSManager.kt
@@ -26,6 +26,7 @@ object NMSManager {
         supportedVersions["v1_14_R1"] = 9
         supportedVersions["v1_16_R1"] = 10
         supportedVersions["v1_17_R1"] = 11
+        supportedVersions["v1_18_R1"] = 12
 
         val pkg: String = Bukkit.getServer().javaClass.`package`.name
         var version = pkg.substring(pkg.lastIndexOf(".") + 1)
@@ -56,6 +57,7 @@ object NMSManager {
             9 -> Provider113
             10 -> Provider116
             11 -> Provider117
+            12 -> Provider117
             else -> Provider117
         }
     }


### PR DESCRIPTION
This PR make TitleManager supports Minecraft 1.18 ScoreBoard, since methods are obfuscated.